### PR TITLE
Replaces print statements with Apple's unified logging system

### DIFF
--- a/ShipShape/Activities/AppReview/AppReviewView.swift
+++ b/ShipShape/Activities/AppReview/AppReviewView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct AppReviewView: View {
     @Environment(ASCClient.self) var client
     @State private var loadState = LoadState.loading
+    @Logger private var logger
 
     var app: ASCApp
 
@@ -40,7 +41,7 @@ struct AppReviewView: View {
                 try await client.fetchVersions(of: app)
                 loadState = .loaded
             } catch {
-                print(error.localizedDescription)
+                logger.error("\(error.localizedDescription)")
                 loadState = .failed
             }
         }

--- a/ShipShape/Activities/Builds/BuildsView.swift
+++ b/ShipShape/Activities/Builds/BuildsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct BuildsView: View {
     @Environment(ASCClient.self) var client
     @State private var loadState = LoadState.loading
+    @Logger private var logger
 
     var app: ASCApp
 
@@ -57,7 +58,7 @@ struct BuildsView: View {
                 try await client.fetchBuilds(of: app)
                 loadState = .loaded
             } catch {
-                print(error.localizedDescription)
+                logger.error("\(error.localizedDescription)")
                 loadState = .failed
             }
         }

--- a/ShipShape/Activities/CustomerReviews/CustomerReviewsView.swift
+++ b/ShipShape/Activities/CustomerReviews/CustomerReviewsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CustomerReviewsView: View {
     @Environment(ASCClient.self) var client
     @State private var loadState = LoadState.loading
+    @Logger private var logger
 
     var app: ASCApp
 
@@ -51,7 +52,7 @@ struct CustomerReviewsView: View {
                 try await client.fetchReviews(of: app)
                 loadState = .loaded
             } catch {
-                print(error.localizedDescription)
+                logger.error("\(error.localizedDescription)")
                 loadState = .failed
             }
         }

--- a/ShipShape/Activities/InAppPurchases/InAppPurchasesView.swift
+++ b/ShipShape/Activities/InAppPurchases/InAppPurchasesView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct InAppPurchasesView: View {
     @Environment(ASCClient.self) var client
     @State private var loadState = LoadState.loading
+    @Logger private var logger
 
     var app: ASCApp
 
@@ -46,7 +47,7 @@ struct InAppPurchasesView: View {
                 try await client.fetchInAppPurchases(of: app)
                 loadState = .loaded
             } catch {
-                print(error.localizedDescription)
+                logger.error("\(error.localizedDescription)")
                 loadState = .failed
             }
         }

--- a/ShipShape/Activities/Localizations/LocalizationsView.swift
+++ b/ShipShape/Activities/Localizations/LocalizationsView.swift
@@ -13,6 +13,7 @@ struct LocalizationsView: View {
     @State private var loadState = LoadState.loading
     @State private var availableLocales: [String] = []
     @State private var selectedLocale: String = ""
+    @Logger private var logger
 
     var app: ASCApp
 

--- a/ShipShape/Activities/Localizations/LocalizationsView.swift
+++ b/ShipShape/Activities/Localizations/LocalizationsView.swift
@@ -70,7 +70,7 @@ struct LocalizationsView: View {
 
             loadState = .loaded
         } catch {
-            print(error.localizedDescription)
+            logger.error("\(error.localizedDescription)")
             loadState = .failed
         }
     }

--- a/ShipShape/Activities/Screenshots/ScreenshotsView.swift
+++ b/ShipShape/Activities/Screenshots/ScreenshotsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ScreenshotsView: View {
     @Environment(ASCClient.self) var client
     @State private var loadState = LoadState.loading
+    @Logger private var logger
 
     var app: ASCApp
 
@@ -44,7 +45,7 @@ struct ScreenshotsView: View {
 
                 loadState = .loaded
             } catch {
-                print(error.localizedDescription)
+                logger.error("\(error.localizedDescription)")
                 loadState = .failed
             }
         }

--- a/ShipShape/Activities/Subscriptions/SubscriptionsView.swift
+++ b/ShipShape/Activities/Subscriptions/SubscriptionsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct SubscriptionsView: View {
     @Environment(ASCClient.self) var client
     @State private var loadState = LoadState.loading
+    @Logger private var logger
 
     var app: ASCApp
 
@@ -57,7 +58,7 @@ struct SubscriptionsView: View {
                 try await client.fetchSubscriptions(of: app)
                 loadState = .loaded
             } catch {
-                print(error.localizedDescription)
+                logger.error("\(error.localizedDescription)")
                 loadState = .failed
             }
         }

--- a/ShipShape/Activities/Versions/VersionsView.swift
+++ b/ShipShape/Activities/Versions/VersionsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct VersionsView: View {
     @Environment(ASCClient.self) var client
     @State private var loadState = LoadState.loading
+    @Logger private var logger
 
     var app: ASCApp
 
@@ -41,7 +42,7 @@ struct VersionsView: View {
                 try await client.fetchVersions(of: app)
                 loadState = .loaded
             } catch {
-                print(error.localizedDescription)
+                logger.error("\(error.localizedDescription)")
                 loadState = .failed
             }
         }

--- a/ShipShape/Activities/Welcome/WelcomeView.swift
+++ b/ShipShape/Activities/Welcome/WelcomeView.swift
@@ -20,6 +20,8 @@ struct WelcomeView: View {
     @State private var key = ""
     @State private var keyID = ""
     @State private var keyIssuerID = ""
+    
+    @Logger private var logger
 
     var isMissingUserData: Bool {
         key.isEmpty || keyID.isEmpty || keyIssuerID.isEmpty
@@ -122,7 +124,7 @@ struct WelcomeView: View {
         } catch {
             errorMessage = "There was a problem reading the key file."
             isShowingError = true
-            print(error.localizedDescription)
+            logger.error("\(error.localizedDescription)")
             return false
         }
     }

--- a/ShipShape/Client/ASCClient.swift
+++ b/ShipShape/Client/ASCClient.swift
@@ -25,6 +25,9 @@ class ASCClient {
 
     /// The URLSession-compatible type to use for networking.
     var session: any URLSessionProtocol
+    
+    @ObservationIgnored
+    @Logger private var logger
 
     init(key: String, keyID: String, issuerID: String, session: any URLSessionProtocol = URLSession.shared) {
         self.key = key
@@ -45,9 +48,9 @@ class ASCClient {
         request.setValue("Bearer \(jwt)", forHTTPHeaderField: "authorization")
         let (result, _) = try await session.data(for: request, delegate: nil)
 
-        // Print the JSON we get back, for inspection purposes.
+        // Log the JSON we get back, for inspection purposes.
         if let stringResult = String(data: result, encoding: .utf8) {
-            print(stringResult)
+            logger.debug("\(stringResult)")
         }
 
         let decoder = JSONDecoder()

--- a/ShipShape/Settings/UserSettings.swift
+++ b/ShipShape/Settings/UserSettings.swift
@@ -17,6 +17,9 @@ class UserSettings {
     private(set) var apiKey: String?
     private(set) var apiKeyID: String?
     private(set) var apiKeyIssuer: String?
+    
+    @ObservationIgnored
+    @Logger private var logger
 
     /// A Set containing bundle IDs for apps that should be hidden.
     var hiddenApps: Set<String>
@@ -80,11 +83,11 @@ class UserSettings {
         let status = SecItemAdd(query as CFDictionary, nil)
 
         if status == errSecSuccess {
-            print("Keychain item added successfully.")
+            logger.info("Keychain item added successfully.")
         } else if status == errSecDuplicateItem {
-            print("Item already exists.")
+            logger.error("Item already exists.")
         } else {
-            print("Keychain error: \(status)")
+            logger.error("Keychain error: \(status)")
         }
     }
 

--- a/ShipShape/Utilities/Logger.swift
+++ b/ShipShape/Utilities/Logger.swift
@@ -1,0 +1,31 @@
+//
+// Logger.swift
+// ShipShape
+// https://www.github.com/twostraws/ShipShape
+// See LICENSE for license information.
+//
+
+import Foundation
+import OSLog
+
+@propertyWrapper
+public struct Logger {
+    public static var defaultSubsystem: String {
+        return Bundle.main.bundleIdentifier ?? "ShipShape"
+    }
+
+    let logger: os.Logger
+
+    public var wrappedValue: os.Logger {
+        get {
+            return logger
+        }
+    }
+
+    public init(subsystem: String = Self.defaultSubsystem, category: String = #file) {
+        self.logger = os.Logger(
+            subsystem: subsystem,
+            category: category
+        )
+    }
+}


### PR DESCRIPTION
### Description
These changes introduce a new property wrapper, `@Logger`, and replaces use of print statements with Apple's system for [unified logging](https://developer.apple.com/documentation/os/logging). 

Benefits of using the logger over `print()` include the ability to filter for logging messages in the console. This can allow for viewing messages just for your process, or for a specific subsystem, category, or file. Filtering can also be done to look only for debug messages, errors, and more.

This PR proposes using the `Bundle.main.bundleIdentifier` as the default `subsystem`, falling back to "ShipShape", and the file from which the log originated as the default `category`.

### Use
Declare the property at the top of your class, enum, struct, etc.
```Swift
@Logger private var logger
```

The default subsystem and/or category may be overwritten for additional granularity:
```Swift
@Logger(subsystem: "Networking", category: "JWT Token") private var logger
```


To write your log determine a relevant logging level:
```Swift
logger.info("WelcomeView was shown")
logger.debug("Raw JSON response: \(stringResult)")
logger.error("An unknown error occurred: \(error.localizedDescription)")
```

For a complete list of available log levels refer to [Apple's Logger documentation](https://developer.apple.com/documentation/os/logger).

When declaring `@Logger private var logger` in an `@Observable` class the `ObservationIgnored` macro must be used to prevent the `@Observable` macro from treating it as a computed property:
```Swift
@ObservationIgnored
@Logger private var logger
```

### Notes
_This is such a cool project and I hope the proposed changes are useful!_