### PR TITLE
Added basic feature to select the Locale

### DIFF
--- a/ShipShape/Activities/ASCApp.swift
+++ b/ShipShape/Activities/ASCApp.swift
@@ -62,6 +62,7 @@ final class ASCApp: Decodable, Hashable, Identifiable {
         var name: String
         var bundleId: String
         var sku: String
+        var primaryLocale: String
     }
 
     // MARK: Example
@@ -71,7 +72,8 @@ final class ASCApp: Decodable, Hashable, Identifiable {
             attributes: Attributes(
                 name: "Epic App Idea",
                 bundleId: "amazing.app.id",
-                sku: "123"
+                sku: "123",
+                primaryLocale: "en-US"
             ),
             customerReviews: [ASCCustomerReview.example, ASCCustomerReview.example2],
             versions: [ASCAppVersion.example, ASCAppVersion.example2],


### PR DESCRIPTION
Small enhancement to switch through the localizations. But there are more fields in App Store Connect which can be localised such as 
- App Name
- Subtitle
- What's New

For now I only enhanced the current view to localise Keywords and Description