### PR TITLE
Prevents decode error for unreleased apps

### DIFF
--- a/ShipShape/Activities/Availability/ASCAppAvailability.swift
+++ b/ShipShape/Activities/Availability/ASCAppAvailability.swift
@@ -19,7 +19,7 @@ struct ASCAppAvailability: Comparable, Decodable, Hashable, Identifiable {
 
     struct Attributes: Decodable, Hashable {
         var available: Bool
-        var releaseDate: String
+        var releaseDate: String?
         var preOrderEnabled: Bool
         var preOrderPublishDate: Date?
         var contentStatuses: [String]

--- a/ShipShape/Extensions/Array-ContentStatuses.swift
+++ b/ShipShape/Extensions/Array-ContentStatuses.swift
@@ -15,6 +15,7 @@ extension Array where Element == String {
             case "CANNOT_SELL": "Cannot Sell 🔴"
             case "MISSING_GRN": "Missing Game Registration Number ⚠️"
             case "PROCESSING_TO_AVAILABLE": "Processing to Available"
+            case "AVAILABLE_FOR_SALE_UNRELEASED_APP": "Available for sale, unreleased app"
             default: string
             }
         }.joined(separator: "\n")


### PR DESCRIPTION
### Details
When making calls to `/v2/appAvailabilities/{id}/territoryAvailabilities` a decoding error would occur if the response included a `null` value for the `releaseDate` key:

```
ShipShape/ASCClient.swift:78: Fatal error: Failed to decode due to missing String value - Cannot get value of type String -- found null value instead
```

 This pull request includes the following changes:

- Update `releaseDate` in the `Attributes` structure in `ASCAppAvailability` to be an optional
- Add a case for `AVAILABLE_FOR_SALE_UNRELEASED_APP` in `Array-ContentStatuses`

### Screenshots
Before:
<img width="1076" alt="Screenshot 2025-05-22 at 12 03 07 AM" src="https://github.com/user-attachments/assets/c00a4eac-8f3f-4128-b119-2684ea308c2c" />


After:
<img width="1076" alt="Screenshot 2025-05-22 at 12 02 13 AM" src="https://github.com/user-attachments/assets/283d8a68-6728-4cfb-b132-e75cfacab901" />
