### PR TITLE
Updates formatting for app review notes

### DIFF
--- a/ShipShape/Activities/AppReview/AppReviewView.swift
+++ b/ShipShape/Activities/AppReview/AppReviewView.swift
@@ -21,7 +21,9 @@ struct AppReviewView: View {
                 if let reviewDetails = app.reviewDetails.first {
                     LabeledContent("First Name", value: reviewDetails.attributes.contactFirstName ?? DefaultValues.unknown)
                     LabeledContent("Last Name", value: reviewDetails.attributes.contactLastName ?? DefaultValues.unknown)
-                    LabeledContent("Notes", value: reviewDetails.attributes.notes ?? DefaultValues.notSet)
+                    Section("Notes") {
+                        Text(reviewDetails.attributes.notes ?? DefaultValues.notSet)
+                    }
                 } else {
                     Text("No app review details.")
                 }

--- a/ShipShape/Activities/AppReview/AppReviewView.swift
+++ b/ShipShape/Activities/AppReview/AppReviewView.swift
@@ -50,4 +50,5 @@ struct AppReviewView: View {
 
 #Preview {
     AppReviewView(app: ASCApp.example)
+        .environment(ASCClient.example)
 }

--- a/ShipShape/Client/ASCClient.swift
+++ b/ShipShape/Client/ASCClient.swift
@@ -172,4 +172,13 @@ class ASCClient {
 
         return try await keyCollection.sign(payload, kid: keyID)
     }
+    
+    // MARK: Example
+    static var example: ASCClient {
+        ASCClient(
+            key: "Example Key",
+            keyID: "Example KeyID",
+            issuerID: "Example Issuer ID"
+        )
+    }
 }

--- a/ShipShape/Client/ASCClient.swift
+++ b/ShipShape/Client/ASCClient.swift
@@ -172,7 +172,7 @@ class ASCClient {
 
         return try await keyCollection.sign(payload, kid: keyID)
     }
-    
+
     // MARK: Example
     static var example: ASCClient {
         ASCClient(


### PR DESCRIPTION
### Details
This pull request proposes a small change to the display of app review notes for macOS and iOS. The current implementation forces a trailing alignment for text in the notes field. The updated implementation moves notes into their own `Section`.

This has the benefit of a slightly improved layout on macOS, but a much nicer layout on iOS.

Also introduces an `example` instance of `ASCClient`, and fixes the SwiftUI preview in `AppReviewView`.

### Screenshots
macOS, before:
<img width="1076" alt="before" src="https://github.com/user-attachments/assets/1e45e51a-96dc-4278-ab20-8f2e857a945f" />

macOS, after:
<img width="1076" alt="after" src="https://github.com/user-attachments/assets/9be2ea92-bb74-441c-b374-1e851370aafc" />

iOS, proposed new layout on top, original layout on bottom:
<img width="541" alt="Screenshot 2025-05-21 at 11 12 13 PM" src="https://github.com/user-attachments/assets/4d2fa077-37f1-48e9-8137-c0460c8e6a26" />
