### PR TITLE
Improves BuildView 

### DIFF
--- a/ShipShape/Activities/Builds/ASCAppBuild.swift
+++ b/ShipShape/Activities/Builds/ASCAppBuild.swift
@@ -18,6 +18,7 @@ struct ASCAppBuild: Decodable, Hashable, Identifiable {
         var expired: Bool
         var minOsVersion: String
         var iconAssetToken: ASCImageAsset?
+        var processingState: String
     }
 
     // MARK: Example
@@ -30,7 +31,8 @@ struct ASCAppBuild: Decodable, Hashable, Identifiable {
                 expirationDate: Date.now,
                 expired: false,
                 minOsVersion: "14.0",
-                iconAssetToken: ASCImageAsset.example
+                iconAssetToken: ASCImageAsset.example,
+                processingState: "VALID"
             )
         )
     }

--- a/ShipShape/Activities/Builds/ASCAppBuild.swift
+++ b/ShipShape/Activities/Builds/ASCAppBuild.swift
@@ -17,7 +17,7 @@ struct ASCAppBuild: Decodable, Hashable, Identifiable {
         var expirationDate: Date
         var expired: Bool
         var minOsVersion: String
-        var iconAssetToken: ASCImageAsset
+        var iconAssetToken: ASCImageAsset?
     }
 
     // MARK: Example

--- a/ShipShape/Activities/Builds/BuildsView.swift
+++ b/ShipShape/Activities/Builds/BuildsView.swift
@@ -27,19 +27,25 @@ struct BuildsView: View {
                 } else {
                     ForEach(sortedBuilds) { build in
                         Section("Version: \(build.attributes.version)") {
-                            AsyncImage(url: build.attributes.iconAssetToken.resolvedURL) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image
-                                        .resizable()
-                                        .frame(maxWidth: 100, maxHeight: 100)
+                            if let imageURL = build.attributes.iconAssetToken?.resolvedURL {
+                                HStack {
+                                    Spacer(minLength: .zero)
+                                    AsyncImage(url: imageURL) { phase in
+                                        switch phase {
+                                        case .success(let image):
+                                            image
+                                                .resizable()
+                                                .frame(maxWidth: 100, maxHeight: 100)
 
-                                case .failure:
-                                    Image(systemName: "questionmark.diamond")
+                                        case .failure:
+                                            Image(systemName: "questionmark.diamond")
 
-                                default:
-                                    ProgressView()
-                                        .controlSize(.large)
+                                        default:
+                                            ProgressView()
+                                                .controlSize(.large)
+                                        }
+                                    }
+                                    Spacer(minLength: .zero)
                                 }
                             }
 

--- a/ShipShape/Activities/Builds/BuildsView.swift
+++ b/ShipShape/Activities/Builds/BuildsView.swift
@@ -15,13 +15,17 @@ struct BuildsView: View {
 
     var app: ASCApp
 
+    private var sortedBuilds: [ASCAppBuild] {
+        app.builds.sorted { $0.attributes.version > $1.attributes.version }
+    }
+
     var body: some View {
         LoadingView(loadState: $loadState, retryAction: load) {
             Form {
                 if app.builds.isEmpty {
                     Text("No builds.")
                 } else {
-                    ForEach(app.builds) { build in
+                    ForEach(sortedBuilds) { build in
                         Section("Version: \(build.attributes.version)") {
                             AsyncImage(url: build.attributes.iconAssetToken.resolvedURL) { phase in
                                 switch phase {

--- a/ShipShape/Activities/Builds/BuildsView.swift
+++ b/ShipShape/Activities/Builds/BuildsView.swift
@@ -43,6 +43,7 @@ struct BuildsView: View {
                                 }
                             }
 
+                            LabeledContent("Processing State", value: build.attributes.processingState.convertFromProcessingState)
                             LabeledContent("Upload Date", value: build.attributes.uploadedDate.formatted())
                             LabeledContent("Expiration Date", value: build.attributes.expirationDate.formatted())
                             LabeledContent("Minimum OS Version", value: build.attributes.minOsVersion)

--- a/ShipShape/Extensions/String-ProcessingState.swift
+++ b/ShipShape/Extensions/String-ProcessingState.swift
@@ -1,0 +1,21 @@
+//
+// String-ProcessingState.swift
+// ShipShape
+// https://www.github.com/twostraws/ShipShape
+// See LICENSE for license information.
+//
+
+import Foundation
+
+extension String {
+    /// Replaces Apple's App Store state hard-coded strings, e.g. `PROCESSING` becomes "Processing".
+    var convertFromProcessingState: String {
+        switch self {
+        case "PROCESSING": "Processing ⏳"
+        case "FAILED": "Failed 🔴"
+        case "INVALID": "Invalid ⚠️"
+        case "VALID": "Valid ✅"
+        default: self
+        }
+    }
+}

--- a/ShipShape/Extensions/String-ProcessingState.swift
+++ b/ShipShape/Extensions/String-ProcessingState.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension String {
-    /// Replaces Apple's App Store state hard-coded strings, e.g. `PROCESSING` becomes "Processing".
+    /// Replaces Apple's strings representing a build's processing state, e.g. `PROCESSING` becomes "Processing".
     var convertFromProcessingState: String {
         switch self {
         case "PROCESSING": "Processing ⏳"


### PR DESCRIPTION
### Details
When making calls to `/v1/apps/{id}/builds` a decoding error would occur if the response included a `null` value for the `iconAssetToken` key:

```
ShipShape/ASCClient.swift:78: Fatal error: Failed to decode due to missing String value - Cannot get value of type String -- found null value instead
```

 This pull request includes the following changes:

- Update `iconAssetToken` in the `Attributes` struct of `ASCAppBuild` to be an optional
- Add `String` extension to convert a build's processing state with `convertFromProcessingState`
- Add a new row in `BuildView` to display a build's processing state
- Only show an image view for `iconAssetToken` when `build.attributes.iconAssetToken?.resolvedURL` is non-nil

### Screenshots
Before, app with icon:
<img width="1202" alt="Screenshot 2025-05-24 at 12 36 59 AM" src="https://github.com/user-attachments/assets/c696978a-3de6-42f9-936c-10902cba6405" />

After, app with icon:
<img width="1202" alt="Screenshot 2025-05-24 at 12 37 35 AM" src="https://github.com/user-attachments/assets/dc228659-166d-4217-899f-059a6e5a45f3" />

After, app without icon:
<img width="1202" alt="Screenshot 2025-05-24 at 12 37 40 AM" src="https://github.com/user-attachments/assets/32c09beb-a05d-4555-9b5c-7e16c72e55bb" />
