### PR TITLE
Fixed an app crash when setting up wrong credentials

### DIFF
--- a/ShipShape.xcodeproj/project.pbxproj
+++ b/ShipShape.xcodeproj/project.pbxproj
@@ -25,9 +25,22 @@
 		517283BC2DDCD6D40064D974 /* ShipShapeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShipShapeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		150395C22DE4E40A00D5D002 /* Exceptions for "ShipShape" folder in "ShipShape" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 51616E6D2DD8EDE8007B8250 /* ShipShape */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		51616E702DD8EDE8007B8250 /* ShipShape */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				150395C22DE4E40A00D5D002 /* Exceptions for "ShipShape" folder in "ShipShape" target */,
+			);
 			path = ShipShape;
 			sourceTree = "<group>";
 		};

--- a/ShipShape/Activities/ASCView.swift
+++ b/ShipShape/Activities/ASCView.swift
@@ -108,7 +108,10 @@ struct ASCView: View {
     func load() async {
         do {
             loadState = .loading
-            try await client.checkConnection()
+
+            guard try await client.checkConnection() else {
+                throw ASCClientError.connectionError
+            }
             try await client.getApps()
             loadState = .loaded
         } catch {

--- a/ShipShape/Activities/ASCView.swift
+++ b/ShipShape/Activities/ASCView.swift
@@ -15,6 +15,7 @@ struct ASCView: View {
     @State private var selectedApp: ASCApp?
     @State private var selectedSection: AppSection?
     @State private var loadState = LoadState.loading
+    @State private var showASCError = false
 
     @State private var isShowingDebugInput = false
     @AppStorage("debugURL") private var debugURL = ""
@@ -85,6 +86,12 @@ struct ASCView: View {
         } message: {
             Text("This will fetch the URL and print it to the debug console, then trigger a crash.")
         }
+        .alert("Error establishing connection to App Store Connect", isPresented: $showASCError) {
+            Button("OK", role: .cancel) { }
+            Button("Clear Credentials", role: .destructive) { userSettings.clearCredentials() }
+        } message: {
+            Text(client.errorMessage)
+        }
     }
 
     init(apiKey: String, apiKeyID: String, apiKeyIssuer: String) {
@@ -101,10 +108,12 @@ struct ASCView: View {
     func load() async {
         do {
             loadState = .loading
+            try await client.checkConnection()
             try await client.getApps()
             loadState = .loaded
         } catch {
             loadState = .failed
+            showASCError.toggle()
         }
     }
 

--- a/ShipShape/Activities/Welcome/WelcomeView.swift
+++ b/ShipShape/Activities/Welcome/WelcomeView.swift
@@ -178,9 +178,20 @@ struct WelcomeView: View {
         guard keyID.isEmpty == false else { return }
         guard keyIssuerID.isEmpty == false else { return }
 
-        userSettings.setAPIKey(key)
-        userSettings.setAPIKeyID(keyID)
-        userSettings.setAPIKeyIssuer(keyIssuerID)
+        let newClient = ASCClient(key: key, keyID: keyID, issuerID: keyIssuerID)
+        Task {
+            do {
+                _ = try await newClient.checkConnection()
+
+                userSettings.setAPIKey(key)
+                userSettings.setAPIKeyID(keyID)
+                userSettings.setAPIKeyIssuer(keyIssuerID)
+
+            } catch {
+                errorMessage = "There was a problem connecting to App Store Connect. Please check your credentials."
+                isShowingError = true
+            }
+        }
     }
 }
 

--- a/ShipShape/Client/ASCClient.swift
+++ b/ShipShape/Client/ASCClient.swift
@@ -49,7 +49,7 @@ class ASCClient {
     }
 
     /// Checks whether the connection to App Store Connect is successful.
-    func checkConnection() async throws {
+    func checkConnection() async throws -> Bool {
         guard let url = URL(string: "https://api.appstoreconnect.apple.com/v1/apps?limit=1") else {
             throw ASCClientError.invalidEndpoint
         }
@@ -68,6 +68,8 @@ class ASCClient {
             errorMessage = "Failed to connect to App Store Connect: \(httpResponse.statusCode)"
             throw ASCClientError.connectionError
         }
+
+        return true
     }
 
     /// Fetches an App Store Connect API and decodes it to a specific type.
@@ -96,18 +98,16 @@ class ASCClient {
         do {
             return try decoder.decode(T.self, from: result)
         } catch DecodingError.keyNotFound(let key, let context) {
-            errorMessage = "Failed to decode due to missing key '\(key)' - \(context.debugDescription)"
+            fatalError("Failed to decode due to missing key '\(key)' - \(context.debugDescription)")
         } catch DecodingError.typeMismatch(_, let context) {
-            errorMessage = "Failed to decode due to type mismatch - \(context.debugDescription)"
+            fatalError("Failed to decode due to type mismatch - \(context.debugDescription)")
         } catch DecodingError.valueNotFound(let type, let context) {
-            errorMessage = "Failed to decode due to missing \(type) value - \(context.debugDescription)"
+            fatalError("Failed to decode due to missing \(type) value - \(context.debugDescription)")
         } catch DecodingError.dataCorrupted(let context) {
-            errorMessage = "Failed to decode: it appears to be invalid JSON: \(context)"
+            fatalError("Failed to decode: it appears to be invalid JSON: \(context)")
         } catch {
-            errorMessage = "Failed to decode: \(error.localizedDescription)"
+            fatalError("Failed to decode: \(error.localizedDescription)")
         }
-
-        throw ASCClientError.decodingFailed
     }
 
     func post<T: Encodable>(_ urlString: String, attaching content: T) async throws -> Bool {

--- a/ShipShape/Client/ASCClient.swift
+++ b/ShipShape/Client/ASCClient.swift
@@ -33,6 +33,9 @@ class ASCClient {
     /// The URLSession-compatible type to use for networking.
     var session: any URLSessionProtocol
 
+    /// Error message when connection or decoding fails.
+    var errorMessage = ""
+
     @ObservationIgnored
     @Logger private var logger
 
@@ -43,6 +46,28 @@ class ASCClient {
         self.keyID = keyID
         self.issuerID = issuerID
         self.session = session
+    }
+
+    /// Checks whether the connection to App Store Connect is successful.
+    func checkConnection() async throws {
+        guard let url = URL(string: "https://api.appstoreconnect.apple.com/v1/apps?limit=1") else {
+            throw ASCClientError.invalidEndpoint
+        }
+
+        let jwt = try await createJWT()
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(jwt)", forHTTPHeaderField: "authorization")
+        let (_, urlResponse) = try await session.data(for: request, delegate: nil)
+
+        guard let httpResponse = urlResponse as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            errorMessage = "Failed to connect to App Store Connect: \(httpResponse.statusCode)"
+            throw ASCClientError.connectionError
+        }
     }
 
     /// Fetches an App Store Connect API and decodes it to a specific type.
@@ -71,16 +96,18 @@ class ASCClient {
         do {
             return try decoder.decode(T.self, from: result)
         } catch DecodingError.keyNotFound(let key, let context) {
-            fatalError("Failed to decode due to missing key '\(key)' - \(context.debugDescription)")
+            errorMessage = "Failed to decode due to missing key '\(key)' - \(context.debugDescription)"
         } catch DecodingError.typeMismatch(_, let context) {
-            fatalError("Failed to decode due to type mismatch - \(context.debugDescription)")
+            errorMessage = "Failed to decode due to type mismatch - \(context.debugDescription)"
         } catch DecodingError.valueNotFound(let type, let context) {
-            fatalError("Failed to decode due to missing \(type) value - \(context.debugDescription)")
+            errorMessage = "Failed to decode due to missing \(type) value - \(context.debugDescription)"
         } catch DecodingError.dataCorrupted(let context) {
-            fatalError("Failed to decode: it appears to be invalid JSON: \(context)")
+            errorMessage = "Failed to decode: it appears to be invalid JSON: \(context)"
         } catch {
-            fatalError("Failed to decode: \(error.localizedDescription)")
+            errorMessage = "Failed to decode: \(error.localizedDescription)"
         }
+
+        throw ASCClientError.decodingFailed
     }
 
     func post<T: Encodable>(_ urlString: String, attaching content: T) async throws -> Bool {

--- a/ShipShape/Client/ASCClientError.swift
+++ b/ShipShape/Client/ASCClientError.swift
@@ -1,0 +1,14 @@
+//
+// ASCClientError.swift
+// ShipShape
+// https://www.github.com/twostraws/ShipShape
+// See LICENSE for license information.
+//
+
+import Foundation
+
+enum ASCClientError: Error {
+    case invalidEndpoint
+    case connectionError
+    case decodingFailed
+}


### PR DESCRIPTION
When wrong credentials are set up the app crashes immediately without option to fix it.
Removed the Fatalerror and added some basic error handling as well as initial function to check if connection can be established. If something goes wrong, Alert will be shown with the option to erase credentials.

Also had to update the xcodeproj file because info.plist was included in "Copy Bundle Resources" which caused the app to not build for iOS.