### PR TITLE
sort by upload date rather than version

### DIFF
--- a/ShipShape/Activities/Builds/BuildsView.swift
+++ b/ShipShape/Activities/Builds/BuildsView.swift
@@ -16,7 +16,7 @@ struct BuildsView: View {
     var app: ASCApp
 
     private var sortedBuilds: [ASCAppBuild] {
-        app.builds.sorted { $0.attributes.version > $1.attributes.version }
+        app.builds.sorted { $0.attributes.uploadedDate > $1.attributes.uploadedDate }
     }
 
     var body: some View {


### PR DESCRIPTION
This addresses Issue #24 , changing the sort order of the list of builds to be decreasing by date uploaded.